### PR TITLE
Recursively replace $ref paths in messagebox schema

### DIFF
--- a/src/Http/MessageSchemaMiddleware.php
+++ b/src/Http/MessageSchemaMiddleware.php
@@ -186,9 +186,11 @@ final class MessageSchemaMiddleware implements RequestHandlerInterface
             $jsonSchema['items'] = $this->jsonSchemaToOpenApiSchema($jsonSchema['items']);
         }
 
-        if(isset($jsonSchema['$ref'])) {
-            $jsonSchema['$ref'] = str_replace('definitions', 'components/schemas', $jsonSchema['$ref']);
-        }
+        array_walk_recursive($jsonSchema, static function (&$value, $key) {
+            if ('$ref' === $key) {
+                $value = str_replace('definitions', 'components/schemas', $value);
+            }
+        });
 
         return $jsonSchema;
     }


### PR DESCRIPTION
If e.g. `oneOf` types are used, the `$ref` prop might by nested inside the `oneOf` prop.

```json
"oneOf": [
    {
        "$ref": "#/definitions/Dog"
    },
    {
        "$ref": "#/definitions/Cat"
    }
]
```